### PR TITLE
Asynchronously read resources

### DIFF
--- a/Books.Api/Books.Api.csproj
+++ b/Books.Api/Books.Api.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Controllers\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/Books.Api/Books.Api.csproj
+++ b/Books.Api/Books.Api.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Books.Api/BooksProfile.cs
+++ b/Books.Api/BooksProfile.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+
+namespace Books.Api
+{
+    public class BooksProfile : Profile
+    {
+        public BooksProfile()
+        {
+            CreateMap<Entities.Book, Models.Book>()
+                .ForMember(dest => dest.Author, opt => opt.MapFrom(src =>
+                    $"{src.Author.FirstName} {src.Author.LastName}"));
+        }
+    }
+}

--- a/Books.Api/Controllers/BooksController.cs
+++ b/Books.Api/Controllers/BooksController.cs
@@ -23,5 +23,18 @@ namespace Books.Api.Controllers
             var bookEntities = await _booksRepository.GetBooksAsync();
             return Ok(bookEntities);
         }
+
+        [HttpGet]
+        [Route("{id}")]
+        public async Task<IActionResult> GetBook(Guid id)
+        {
+            var bookEntity = await _booksRepository.GetBookAsync(id);
+            if (bookEntity == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(bookEntity);
+        }
     }
 }

--- a/Books.Api/Controllers/BooksController.cs
+++ b/Books.Api/Controllers/BooksController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Books.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Books.Api.Controllers
+{
+    [Route("api/books")]
+    [ApiController]
+    public class BooksController : ControllerBase
+    {
+        private IBooksRepository _booksRepository;
+
+        public BooksController(IBooksRepository booksRepository)
+        {
+            _booksRepository = booksRepository
+                ?? throw new ArgumentNullException(nameof(booksRepository));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetBooks()
+        {
+            var bookEntities = await _booksRepository.GetBooksAsync();
+            return Ok(bookEntities);
+        }
+    }
+}

--- a/Books.Api/Controllers/BooksController.cs
+++ b/Books.Api/Controllers/BooksController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Books.Api.Filters;
 using Books.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,6 +19,7 @@ namespace Books.Api.Controllers
         }
 
         [HttpGet]
+        [BooksResultFilter]
         public async Task<IActionResult> GetBooks()
         {
             var bookEntities = await _booksRepository.GetBooksAsync();
@@ -25,6 +27,7 @@ namespace Books.Api.Controllers
         }
 
         [HttpGet]
+        [BookResultFilter]
         [Route("{id}")]
         public async Task<IActionResult> GetBook(Guid id)
         {

--- a/Books.Api/Controllers/SynchronousBooksController.cs
+++ b/Books.Api/Controllers/SynchronousBooksController.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Books.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Books.Api.Controllers
+{
+    [Route("api/synchronousbooks")]
+    public class SynchronousBooksController : ControllerBase
+    {
+        private IBooksRepository _booksRepository;
+
+        public SynchronousBooksController(IBooksRepository booksRepository)
+        {
+            _booksRepository = booksRepository ??
+                throw new ArgumentNullException(nameof(booksRepository));
+        }
+
+        [HttpGet]
+        public IActionResult GetBooks()
+        {
+            var bookEntities = _booksRepository.GetBooks();
+            return Ok(bookEntities);
+        }
+    }
+}

--- a/Books.Api/Filters/BookResultFilterAttribute.cs
+++ b/Books.Api/Filters/BookResultFilterAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Books.Api.Filters
+{
+    public class BookResultFilterAttribute : ResultFilterAttribute
+    {
+        public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            var resultFromAction = context.Result as ObjectResult;
+            if (resultFromAction?.Value == null
+                || resultFromAction.StatusCode < 200
+                || resultFromAction.StatusCode >= 300)
+            {
+                await next();
+                return;
+            }
+
+            //resultFromAction.Value
+
+            await next();
+        }
+    }
+}

--- a/Books.Api/Filters/BookResultFilterAttribute.cs
+++ b/Books.Api/Filters/BookResultFilterAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -17,7 +18,7 @@ namespace Books.Api.Filters
                 return;
             }
 
-            //resultFromAction.Value
+            resultFromAction.Value = Mapper.Map<Models.Book>(resultFromAction.Value);
 
             await next();
         }

--- a/Books.Api/Filters/BooksResultFilterAttribute.cs
+++ b/Books.Api/Filters/BooksResultFilterAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Books.Api.Filters
+{
+    public class BooksResultFilterAttribute : ResultFilterAttribute
+    {
+        public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            var resultFromAction = context.Result as ObjectResult;
+            if (resultFromAction?.Value == null
+                || resultFromAction.StatusCode < 200
+                || resultFromAction.StatusCode >= 300)
+            {
+                await next();
+                return;
+            }
+
+            resultFromAction.Value = Mapper.Map<IEnumerable<Models.Book>>(resultFromAction.Value);
+
+            await next();
+        }
+    }
+}

--- a/Books.Api/Models/Book.cs
+++ b/Books.Api/Models/Book.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Books.Api.Models
+{
+    public class Book
+    {
+        public Guid Id { get; set; }
+
+        public string Author { get; set; }
+
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/Books.Api/Program.cs
+++ b/Books.Api/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Books.Api.Contexts;
 using Microsoft.AspNetCore;
@@ -17,6 +18,9 @@ namespace Books.Api
     {
         public static void Main(string[] args)
         {
+            // Throttle the thread pool (set available threads to amount of processors)
+            ThreadPool.SetMaxThreads(Environment.ProcessorCount, Environment.ProcessorCount);
+
             var host = CreateWebHostBuilder(args).Build();
 
             // Migrate the database. Best practice = in Main, using service scope

--- a/Books.Api/Properties/launchSettings.json
+++ b/Books.Api/Properties/launchSettings.json
@@ -1,18 +1,18 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
+{
   "iisSettings": {
-    "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:59715",
       "sslPort": 44360
     }
   },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "api/books",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -21,10 +21,10 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "api/values",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/Books.Api/Services/BooksRepository.cs
+++ b/Books.Api/Services/BooksRepository.cs
@@ -25,11 +25,13 @@ namespace Books.Api.Services
 
         public async Task<IEnumerable<Book>> GetBooksAsync()
         {
+            await _context.Database.ExecuteSqlCommandAsync("WAITFOR DELAY '00:00:02';");
             return await _context.Books.Include(b => b.Author).ToListAsync();
         }
 
         public IEnumerable<Book> GetBooks()
         {
+            _context.Database.ExecuteSqlCommand("WAITFOR DELAY '00:00:02';");
             return _context.Books.Include(b => b.Author).ToList();
         }
 

--- a/Books.Api/Services/BooksRepository.cs
+++ b/Books.Api/Services/BooksRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Books.Api.Contexts;
 using Books.Api.Entities;
@@ -25,6 +26,11 @@ namespace Books.Api.Services
         public async Task<IEnumerable<Book>> GetBooksAsync()
         {
             return await _context.Books.Include(b => b.Author).ToListAsync();
+        }
+
+        public IEnumerable<Book> GetBooks()
+        {
+            return _context.Books.Include(b => b.Author).ToList();
         }
 
         public void Dispose()

--- a/Books.Api/Services/IBooksRepository.cs
+++ b/Books.Api/Services/IBooksRepository.cs
@@ -6,7 +6,7 @@ namespace Books.Api.Services
 {
     public interface IBooksRepository
     {
-        //IEnumerable<Entities.Book> GetBooks();
+        IEnumerable<Entities.Book> GetBooks();
 
         //Entities.Book GetBook(Guid id);
 

--- a/Books.Api/Startup.cs
+++ b/Books.Api/Startup.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AutoMapper;
 using Books.Api.Contexts;
 using Books.Api.Services;
 using Microsoft.AspNetCore.Builder;
@@ -38,6 +39,8 @@ namespace Books.Api
 
             // DbContext is registered with a scoped lifetime, so this must be the same lifetime or less
             services.AddScoped<IBooksRepository, BooksRepository>();
+
+            services.AddAutoMapper();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Books.Api/Startup.cs
+++ b/Books.Api/Startup.cs
@@ -40,6 +40,10 @@ namespace Books.Api
             // DbContext is registered with a scoped lifetime, so this must be the same lifetime or less
             services.AddScoped<IBooksRepository, BooksRepository>();
 
+            Mapper.Initialize(cfg => {
+                cfg.AddProfile<BooksProfile>();
+            });
+
             services.AddAutoMapper();
         }
 


### PR DESCRIPTION
Async code has a tendency to bubble up application layers due to compiler errors and warnings.
- Can't await if the calling method isn't marked with the `async` modifier

Keep models separate (Entities vs DTO Models)
- Mixing models and responsibilities between layers leads to evolvability issues

Result filters run right before and after the result is executed
- Makes them a good location for mapping code
- Makes the mapping code reusable
